### PR TITLE
[JITERA] Add LoginControllerTest for Jitera

### DIFF
--- a/tests/jitera/LoginControllerTest.php
+++ b/tests/jitera/LoginControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is based on EC-CUBE's test as a template for Jitera environment.
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Jitera;
+
+use Eccube\Tests\Web\AbstractWebTestCase;
+
+class LoginControllerTest extends AbstractWebTestCase
+{
+    public function testRoutingAdminLogin()
+    {
+        $this->client->request('GET', $this->generateUrl('admin_login'));
+
+        // ログイン
+        $this->assertEquals(
+            200,
+            $this->client->getResponse()->getStatusCode()
+        );
+    }
+
+    public function testRoutingAdminLoginCheck()
+    {
+        // see https://stackoverflow.com/a/38661340/4956633
+        $this->client->request(
+            'POST', $this->generateUrl('admin_login'),
+            [
+                'login_id' => 'admin',
+                'password' => 'password',
+                '_csrf_token' => 'dummy',
+            ]
+        );
+
+        $this->assertNotNull(static::getContainer()->get('security.token_storage')->getToken(), 'ログインしているかどうか');
+    }
+
+    public function testRoutingAdminLogin未ログインの場合は302エラーがかえる()
+    {
+        $this->client->request('GET', $this->generateUrl('admin_homepage'));
+
+        // ログイン
+        $this->assertEquals(
+            302,
+            $this->client->getResponse()->getStatusCode()
+        );
+    }
+}


### PR DESCRIPTION
## Overview
This pull request introduces a new test case for the `LoginController` in the Jitera environment. The test is designed to ensure that the login functionality works as expected.

## Changes
- Created a new file `LoginControllerTest.php` in the `/tests/jitera/` directory.
- The test class `LoginControllerTest` extends `AbstractWebTestCase` to leverage the existing testing framework.
- Implemented the following test methods:
  - `testRoutingAdminLogin`: Verifies that the admin login page returns a 200 status code.
  - `testRoutingAdminLoginCheck`: Tests the login functionality by posting valid credentials and checks if the user is authenticated.
  - `testRoutingAdminLogin未ログインの場合は302エラーがかえる`: Ensures that accessing the admin homepage without being logged in returns a 302 status code.

This test file is based on the existing tests in the EC-CUBE framework and has been adjusted to fit the Jitera project standards.
